### PR TITLE
Implement VS Code Formatter (#535)

### DIFF
--- a/build/test.ps1
+++ b/build/test.ps1
@@ -38,8 +38,27 @@ function Test-One {
     }
 }
 
+function Test-VSCode {
+    Param([string] $path);
+
+    Write-Host "##[info]Testing VSCode Extension inside $path..."    
+    Push-Location (Join-Path $PSScriptRoot $path)
+        npm run unittest
+    Pop-Location
+
+    if ($LastExitCode -ne 0) {
+        Write-Host "##vso[task.logissue type=error;]Failed to test VSCode inside $path"
+        $script:all_ok = $False
+    }
+}
+
 Test-One '../QsCompiler.sln'
 
+if ($Env:ENABLE_VSIX -ne "false") {
+    Test-VSCode '../src/VSCodeExtension'
+} else {
+    Write-Host "##vso[task.logissue type=warning;]VSIX building skipped due to ENABLE_VSIX variable."
+}
 
 if (-not $all_ok) 
 {

--- a/src/VSCodeExtension/.mocharc.json
+++ b/src/VSCodeExtension/.mocharc.json
@@ -1,0 +1,5 @@
+{
+    "extension": ["ts"],
+    "spec": "src/tests/unit/**/*.test.ts",
+    "require": "ts-node/register"
+  }

--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -101,7 +101,8 @@
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "npm run compile && node ./node_modules/vscode/bin/test"
+        "test": "npm run compile && node ./node_modules/vscode/bin/test",
+        "unittest": "mocha"
     },
     "dependencies": {
         "decompress-zip": "^0.2.2",
@@ -123,14 +124,15 @@
         "vscode": "^1.1.34",
         "typescript": "^2.6.1",
         "tslint": "^5.8.0",
-        "mocha": "^5.2.0",
+        "ts-node": "^8.10.2",
+        "mocha": "^8.0.0",
         "@types/yeoman-generator": "^3.1.4",
         "@types/yosay": "^0.0.29",
         "yeoman-test": "^1.7.0",
         "yeoman-assert": "^3.1.0",
         "@types/yeoman-environment": "^2.3.3",
         "@types/node": "^9.6.5",
-        "@types/mocha": "^5.2.0",
+        "@types/mocha": "^8.0.0",
         "@types/which": "1.3.1",
         "@types/tmp": "0.0.33",
         "@types/semver": "^6.0.0",

--- a/src/VSCodeExtension/src/commands.ts
+++ b/src/VSCodeExtension/src/commands.ts
@@ -25,7 +25,7 @@ export function registerCommand(context: vscode.ExtensionContext, name: string, 
     )
 }
 
-export function createNewProject(context: vscode.ExtensionContext) {    
+export function createNewProject(context: vscode.ExtensionContext) {
     let env = yeoman.createEnv();
     env.options.extensionPath = context.extensionPath;
     env.registerStub(QSharpGenerator, 'qsharp:app');
@@ -41,13 +41,13 @@ export function createNewProject(context: vscode.ExtensionContext) {
 export function installTemplates(dotNetSdk: DotnetInfo, packageInfo?: IPackageInfo) {
     let packageVersion =
         oc(packageInfo).nugetVersion
-        ? `::${packageInfo!.nugetVersion}`
-        : "";
+            ? `::${packageInfo!.nugetVersion}`
+            : "";
     let proc = cp.spawn(
         dotNetSdk.path,
         ["new", "--install", `Microsoft.Quantum.ProjectTemplates${packageVersion}`]
     );
-    
+
     let errorMessage = "";
     proc.stderr.on(
         'data', data => {
@@ -57,7 +57,7 @@ export function installTemplates(dotNetSdk: DotnetInfo, packageInfo?: IPackageIn
     proc.stdout.on(
         'data', data => {
             console.log("" + data);
-        }        
+        }
     )
 
     proc.on(
@@ -102,7 +102,7 @@ export function installOrUpdateIQSharp(dotNetSdk: DotnetInfo, requiredVersion?: 
                     return promisify(cp.exec)(
                         `"${dotNetSdk.path}" tool uninstall --global Microsoft.Quantum.IQSharp`
                     )
-                    .then(() => true);
+                        .then(() => true);
                 }
                 return true;
             }
@@ -112,24 +112,24 @@ export function installOrUpdateIQSharp(dotNetSdk: DotnetInfo, requiredVersion?: 
                 if (needToInstall) {
                     let versionSpec =
                         requiredVersion === undefined
-                        ? ""
-                        : `::${requiredVersion}`;
+                            ? ""
+                            : `::${requiredVersion}`;
                     return promisify(cp.exec)(
                         `"${dotNetSdk.path}" tool install --global Microsoft.Quantum.IQSharp${versionSpec}`
                     )
-                    .then(() => {
-                        // Check what version actually got installed and report that back.
-                        findIQSharpVersion()
-                            .then(installedVersion => {
-                                if (installedVersion === undefined) {
-                                    throw new Error("Could not detect IQ# version after installing.");
-                                }
-                                if (installedVersion["iqsharp"] === undefined) {
-                                    throw new Error("Newly installed IQ# did not report a version.");
-                                }
-                                vscode.window.showInformationMessage(`Successfully installed IQ# version ${installedVersion["iqsharp"]}`);
-                            });
-                    });
+                        .then(() => {
+                            // Check what version actually got installed and report that back.
+                            findIQSharpVersion()
+                                .then(installedVersion => {
+                                    if (installedVersion === undefined) {
+                                        throw new Error("Could not detect IQ# version after installing.");
+                                    }
+                                    if (installedVersion["iqsharp"] === undefined) {
+                                        throw new Error("Newly installed IQ# did not report a version.");
+                                    }
+                                    vscode.window.showInformationMessage(`Successfully installed IQ# version ${installedVersion["iqsharp"]}`);
+                                });
+                        });
                 }
             }
         )

--- a/src/VSCodeExtension/src/extension.ts
+++ b/src/VSCodeExtension/src/extension.ts
@@ -10,11 +10,12 @@ import { DotnetInfo, requireDotNetSdk, findDotNetSdk } from './dotnet';
 import { getPackageInfo } from './packageInfo';
 import { installTemplates, createNewProject, registerCommand, openDocumentationHome, installOrUpdateIQSharp } from './commands';
 import { LanguageServer } from './languageServer';
+import { formatDocument } from "./formatter/format-document";
 
 /**
  * Returns the root folder for the current workspace.
  */
-function findRootFolder() : string {
+function findRootFolder(): string {
     // FIXME: handle multiple workspace folders here.
     let workspaceFolders = vscode.workspace.workspaceFolders;
     if (workspaceFolders) {
@@ -39,7 +40,7 @@ export async function activate(context: vscode.ExtensionContext) {
     let dotNetSdkVersion = packageInfo === undefined ? undefined : packageInfo.requiredDotNetCoreSDK;
 
     // Get any .NET Core SDK version number to report in telemetry.
-    var dotNetSdk : DotnetInfo | undefined;
+    var dotNetSdk: DotnetInfo | undefined;
     try {
         dotNetSdk = await findDotNetSdk();
     } catch {
@@ -95,6 +96,18 @@ export async function activate(context: vscode.ExtensionContext) {
             );
         }
     );
+
+    // Register Q# formatter
+    context.subscriptions.push(
+        vscode.languages.registerDocumentFormattingEditProvider({
+            scheme: 'file',
+            language: 'qsharp',
+        }, {
+            provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
+                return formatDocument(document);
+            }
+        })
+    )
 
     let rootFolder = findRootFolder();
 

--- a/src/VSCodeExtension/src/formatter/format-document.ts
+++ b/src/VSCodeExtension/src/formatter/format-document.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as vscode from "vscode";
+import { FormatRule, formatter } from "./formatter";
+import indentRules from "./rules/indent";
+import operationRules from "./rules/operation";
+import controlStructureRules from "./rules/control-structure";
+
+const rules: FormatRule[] = [
+    ...indentRules,
+    ...operationRules,
+    ...controlStructureRules,
+];
+
+export const formatDocument = (
+    document: vscode.TextDocument
+): vscode.TextEdit[] => {
+    const lines: vscode.TextLine[] = Array.from(
+        Array(document.lineCount),
+        (_, lineNo) => document.lineAt(lineNo)
+    );
+
+    const formattedLines: vscode.TextEdit[] = lines
+        .map((line) => {
+            const formattedLine: string = formatter(line.text, rules);
+            return formattedLine !== line.text
+                ? vscode.TextEdit.replace(line.range, formattedLine)
+                : null;
+        })
+        .filter((e): e is vscode.TextEdit => e != null);
+    return formattedLines;
+};

--- a/src/VSCodeExtension/src/formatter/formatter.ts
+++ b/src/VSCodeExtension/src/formatter/formatter.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type FormatRule = (code: string) => string;
+
+export const formatter = (code: string, rules: FormatRule[]): string =>
+    rules.reduce((formattedCode, rule) => rule(formattedCode), code);

--- a/src/VSCodeExtension/src/formatter/rules/control-structure.ts
+++ b/src/VSCodeExtension/src/formatter/rules/control-structure.ts
@@ -1,0 +1,17 @@
+import { FormatRule } from "../formatter";
+
+/**
+ * Laves just one space after an if statement
+ *
+ * @param code input string
+ *
+ * @example `if                              (1 == 1){H(qs[0]);}` ->
+ * `if (1 == 1){H(qs[0]);}`
+ *
+ * more examples in the unit tests
+ */
+export const spaceAfterIf: FormatRule = (code: string): string => {
+    return code.replace(/(^| +|;|})if[ \n]*/, "$1if ");
+};
+
+export default [spaceAfterIf];

--- a/src/VSCodeExtension/src/formatter/rules/indent.ts
+++ b/src/VSCodeExtension/src/formatter/rules/indent.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { FormatRule } from "../formatter";
+
+/**
+ * Removes whitespace from left of `namespace`.
+ *
+ * @param code input string
+ *
+ * @example `   namespace   Foo   {}` ->
+ * `namespace Foo {}`
+ */
+export const namespaceRule: FormatRule = (code: string) => {
+    const namespaceMatcher: RegExp = /^\s*namespace\s*(\w+)\s*(\S|\S.*\S)\s*$/g;
+
+    return code.replace(namespaceMatcher, (match, namespace, rest) => `namespace ${namespace} ${rest}`);
+};
+
+export default [namespaceRule];

--- a/src/VSCodeExtension/src/formatter/rules/operation.ts
+++ b/src/VSCodeExtension/src/formatter/rules/operation.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+ * Formats operation declarations.
+ *
+ * @param code incoming code
+ *
+ * @example `operation   Foo(q:Qubit,  n   :Int)   :  Bool` ->
+ * `operation Foo (q : Qubit, n : Int) : Bool`
+ */
+export const argsRule = (code: string): string => {
+    const operationMatcher: RegExp = /operation\s*(\w+)\s*(\(.*\))\s*:\s*(\w+)/g;
+    const firstArgMatcher: RegExp = /\(((\w*)\s*:\s*([a-zA-Z]+))/g
+    const restArgMatcher: RegExp = /,\s*((\w*)\s*:\s*([a-zA-Z]+))/g;
+
+    return code.replace(operationMatcher, (match, opName, args, retType) => {
+        args = args
+            .replace(
+                firstArgMatcher,
+                (match: string, group: string, variable: string, type: string) =>
+                    `(${variable} : ${type}`
+            )
+            .replace(
+                restArgMatcher,
+                (match: string, group: string, variable: string, type: string) =>
+                    `, ${variable} : ${type}`
+            );
+        return `operation ${opName} ${args} : ${retType}`;
+    });
+};
+
+export default [argsRule];

--- a/src/VSCodeExtension/src/tests/unit/control-structure.test.ts
+++ b/src/VSCodeExtension/src/tests/unit/control-structure.test.ts
@@ -1,0 +1,98 @@
+import "mocha";
+import * as assert from "assert";
+import { formatter } from "../../formatter/formatter";
+import { spaceAfterIf } from "../../formatter/rules/control-structure";
+
+describe("space after if rule", () => {
+  it("adds space after if statement", () => {
+    const code = "if(1 == 1){H(qs[0]);}";
+    const expectedCode = "if (1 == 1){H(qs[0]);}";
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
+  it("does not add space if it is already there", () => {
+    const code = "if (1 == 1){H(qs[0]);}";
+    const expectedCode = "if (1 == 1){H(qs[0]);}";
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
+  it("replaces an if with several spaces with just one", () => {
+    const code = "if                              (1 == 1){H(qs[0]);}";
+    const expectedCode = "if (1 == 1){H(qs[0]);}";
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
+  it("changes breaklines and whitespace with just one space", () => {
+    const code = `if            
+                       
+              (1 == 1){H(qs[0]);}`;
+
+    const expectedCode = "if (1 == 1){H(qs[0]);}";
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
+  it("changes breaklines and whitespace if there is preceeding code", () => {
+    const code = `H(qs[0]);   if            
+                       
+              (1 == 1){H(qs[0]);}`;
+
+    const expectedCode = "H(qs[0]);   if (1 == 1){H(qs[0]);}";
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
+  it("changes breaklines and whitespace if there is preceeding code and no space after", () => {
+    const code = `H(qs[0]);   if(1 == 1){H(qs[0]);}`;
+    const expectedCode = "H(qs[0]);   if (1 == 1){H(qs[0]);}";
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
+  it("does not change if it is a function call", () => {
+    const code = "myFunctionWithConvenientNameif(parameter)";
+    const expectedCode = "myFunctionWithConvenientNameif(parameter)";
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
+  it("does not add any space if there is an identifier with if in the name", () => {
+    const code = "functionWithifInTheMiddle(parameter)";
+    const expectedCode = "functionWithifInTheMiddle(parameter)";
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
+  it("formats space after if it is preceeding with a semicolon", () => {
+    const code = 'mutable bits = new Result[0];if(1==1){Message("1==1");}';
+    const expectedCode =
+      'mutable bits = new Result[0];if (1==1){Message("1==1");}';
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
+  it("formats space after if it is preceeding with a semicolon with line break", () => {
+    const code = `mutable bits = new Result[0];if 
+                   (1==1){Message(\"1==1\");}`;
+
+    const expectedCode =
+      'mutable bits = new Result[0];if (1==1){Message("1==1");}';
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
+  it("formats space after if it is precceding with a }", () => {
+    const code = `for (idxBit in 1..BitSizeI(max)) {
+                      set bits += [SampleQuantumRandomNumberGenerator()];
+                    }if(2==2){Message("2==2");}`;
+
+    const expectedCode = `for (idxBit in 1..BitSizeI(max)) {
+                      set bits += [SampleQuantumRandomNumberGenerator()];
+                    }if (2==2){Message("2==2");}`;
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+});

--- a/src/VSCodeExtension/src/tests/unit/formatter.test.ts
+++ b/src/VSCodeExtension/src/tests/unit/formatter.test.ts
@@ -1,0 +1,12 @@
+import "mocha";
+import * as assert from "assert";
+import { formatter } from "../../formatter/formatter";
+
+describe("formatter tests", () => {
+  it("with no rules, the code is unchanged", () => {
+    const code = "if(1 == 1){H(qs[0]);}";
+    const expectedCode = "if(1 == 1){H(qs[0]);}";
+
+    assert.equal(formatter(code, []), expectedCode);
+  });
+});

--- a/src/VSCodeExtension/src/tests/unit/indent.test.ts
+++ b/src/VSCodeExtension/src/tests/unit/indent.test.ts
@@ -1,0 +1,51 @@
+import "mocha";
+import * as assert from "assert";
+import { formatter } from "../../formatter/formatter";
+import { namespaceRule } from "../../formatter/rules/indent";
+
+describe("namespace rule", () => {
+    it("no error", () => {
+        const code = "namespace Foo {";
+        const expectedCode = "namespace Foo {";
+
+        assert.equal(formatter(code, []), expectedCode);
+    });
+
+    it("trim whitespace", () => {
+        const expectedCode = "namespace Foo {";
+
+        let code = "     namespace Foo {";
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+
+        code = "namespace Foo {        ";
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+        
+        code = "namespace   Foo {        ";
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+        
+        code = "namespace Foo   {        ";
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+
+        code = "     namespace   Foo   {        ";
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+    });
+
+    it("match lines with inline body", () => {
+        const expectedCode = "namespace Foo { // ... }";
+
+        let code = "     namespace Foo { // ... }";
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+
+        code = "namespace Foo { // ... }        ";
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+        
+        code = "namespace   Foo { // ... }        ";
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+        
+        code = "namespace Foo   { // ... }        ";
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+
+        code = "     namespace   Foo   { // ... }        ";
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+    });
+});

--- a/src/VSCodeExtension/src/tests/unit/operation.test.ts
+++ b/src/VSCodeExtension/src/tests/unit/operation.test.ts
@@ -1,0 +1,55 @@
+import "mocha";
+import * as assert from "assert";
+import { formatter } from "../../formatter/formatter";
+import { argsRule } from "../../formatter/rules/operation";
+
+describe("arguments rule", () => {
+    it("no error", () => {
+        const code = "operation Foo (q : Qubit, n : Int) : Bool";
+        const expectedCode = "operation Foo (q : Qubit, n : Int) : Bool";
+
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+    });
+
+    it("keep leading whitespace", () => {
+        const code = "  operation Foo (q : Qubit, n : Int) : Bool";
+        const expectedCode = "  operation Foo (q : Qubit, n : Int) : Bool";
+
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+    });
+
+    it("remove unnecessary spaces (non-arguments)", () => {
+        const expectedCode = "operation Foo (q : Qubit, n : Int) : Bool";
+
+        let code = "operation   Foo (q : Qubit, n : Int) : Bool";
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+
+        code = "operation Foo   (q : Qubit, n : Int) : Bool";
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+
+        code = "operation Foo (q : Qubit, n : Int)   : Bool";
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+
+        code = "operation Foo (q : Qubit, n : Int) :   Bool";
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+    });
+
+    it("remove unnecessary spaces (arguments)", () => {
+        const expectedCode = "operation Foo (q : Qubit, n : Int) : Bool";
+
+        let code = "operation Foo (q   : Qubit, n : Int) : Bool";
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+
+        code = "operation Foo (q :    Qubit, n : Int) : Bool";
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+
+        code = "operation Foo (q : Qubit, n   : Int) : Bool";
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+
+        code = "operation Foo (q : Qubit, n :   Int) : Bool";
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+
+        code = "operation Foo (q : Qubit,   n : Int) : Bool";
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+    });
+});


### PR DESCRIPTION
* Add Q# formatter

* if rules started implementation

* multispaces

* does not change if it is a function call

* with precceding code

* make text more explicit

* Add more tests

* Restructure formatters

* Remove hello world test

* Remove Operation.qs

* erase space

* Integrate and some little refactoring

* formatting source code

* Update src/VSCodeExtension/src/formatter/rules/indent.ts

Co-authored-by: Raphael Koh <raph.koh@gmail.com>

* changes as suggested

* Add end lines

* Improve comment

* Fix test script and add to build pipeline

* Fix build pipeline

* Fix indent

* Restructure test

* Add tests for namespace rule

* Add tests for operation args rule

Co-authored-by: Andres Rondon <amrondonp@gmail.com>